### PR TITLE
Add interactive project details and telemetry

### DIFF
--- a/src/components/Apps/Apps.jsx
+++ b/src/components/Apps/Apps.jsx
@@ -188,10 +188,21 @@ function Apps() {
   const hasOpenDetails = infoVisible.some(Boolean);
   const sliderIsPlaying = isPlaying && !hasOpenDetails;
 
+  const openInfo = (index) => {
+    const nextInfoVisible = Array(projects.length).fill(false);
+    nextInfoVisible[index] = true;
+    setInfoVisible(nextInfoVisible);
+    setIsPlaying(false);
+  };
+
   const toggleInfo = (index) => {
-    const nextInfoVisible = [...infoVisible];
-    const willShowDetails = !nextInfoVisible[index];
-    nextInfoVisible[index] = !nextInfoVisible[index];
+    const willShowDetails = !infoVisible[index];
+    const nextInfoVisible = Array(projects.length).fill(false);
+
+    if (willShowDetails) {
+      nextInfoVisible[index] = true;
+    }
+
     setInfoVisible(nextInfoVisible);
 
     if (willShowDetails) {
@@ -201,6 +212,25 @@ function Apps() {
 
   const togglePlay = () => {
     setIsPlaying((prev) => !prev);
+  };
+
+  const handleProjectCardClick = (event, index) => {
+    if (event.target.closest('a, button')) {
+      return;
+    }
+
+    openInfo(index);
+  };
+
+  const handleProjectCardKeyDown = (event, index) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      openInfo(index);
+    }
   };
 
   const settings = {
@@ -244,6 +274,10 @@ function Apps() {
               <div key={project.name} className={styles.slideOuter}>
                 <article
                   className={`${styles.slide} ${styles[project.className]}`}
+                  tabIndex={0}
+                  aria-label={`Open details for ${project.name}`}
+                  onClick={(event) => handleProjectCardClick(event, index)}
+                  onKeyDown={(event) => handleProjectCardKeyDown(event, index)}
                   onPointerMove={handleCardPointerMove}
                   onPointerLeave={handleCardPointerLeave}
                 >

--- a/src/components/Apps/apps.module.css
+++ b/src/components/Apps/apps.module.css
@@ -34,6 +34,12 @@
   transition: transform 0.24s ease, box-shadow 0.24s ease,
     border-color 0.24s ease;
   will-change: transform;
+  cursor: pointer;
+}
+
+.slide:focus-visible {
+  outline: 2px solid rgba(70, 240, 255, 0.72);
+  outline-offset: 4px;
 }
 
 .slide:hover {
@@ -198,6 +204,7 @@
     linear-gradient(90deg, rgba(70, 240, 255, 0.12), rgba(163, 230, 53, 0.08));
   backdrop-filter: blur(18px);
   transform: translateZ(54px);
+  cursor: default;
 }
 
 .detailImageFrame {

--- a/src/components/Portfolio/Portfolio.jsx
+++ b/src/components/Portfolio/Portfolio.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
 import { Link } from 'react-scroll';
 import {
   FaArrowRight,
@@ -9,7 +9,42 @@ import {
 import HeroScene from '../HeroScene/HeroScene';
 import styles from './portfolio.module.css';
 
+const telemetryCards = [
+  {
+    status: 'ONLINE',
+    label: 'Interface systems',
+    headline: 'Clean architecture, fast delivery, modern UX.',
+    bars: ['88%', '76%', '94%'],
+    trace: ['38%', '72%', '48%', '86%', '58%'],
+  },
+  {
+    status: 'MEASURING',
+    label: 'Product signal',
+    headline: 'Responsive flows, clear data, reliable interactions.',
+    bars: ['82%', '91%', '74%'],
+    trace: ['52%', '84%', '44%', '76%', '68%'],
+  },
+  {
+    status: 'SYNCED',
+    label: 'Full-stack delivery',
+    headline: 'APIs, UI systems, and product logic working together.',
+    bars: ['93%', '79%', '88%'],
+    trace: ['44%', '66%', '92%', '56%', '78%'],
+  },
+];
+
 function Portfolio() {
+  const [activeTelemetry, setActiveTelemetry] = useState(0);
+  const telemetry = telemetryCards[activeTelemetry];
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setActiveTelemetry((current) => (current + 1) % telemetryCards.length);
+    }, 3200);
+
+    return () => window.clearInterval(intervalId);
+  }, []);
+
   return (
     <section id="portfolio" className={styles.hero}>
       <HeroScene />
@@ -111,16 +146,42 @@ function Portfolio() {
         >
           <div className={styles.telemetryHeader}>
             <span>RC-SD/2026</span>
-            <span>ONLINE</span>
+            <span>{telemetry.status}</span>
           </div>
-          <div className={styles.telemetryBody}>
-            <p>Interface systems</p>
-            <strong>Clean architecture, fast delivery, modern UX.</strong>
-          </div>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={telemetry.label}
+              className={styles.telemetryBody}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.28, ease: 'easeOut' }}
+            >
+              <p>{telemetry.label}</p>
+              <strong>{telemetry.headline}</strong>
+            </motion.div>
+          </AnimatePresence>
           <div className={styles.telemetryBars}>
-            <span style={{ '--level': '88%' }} />
-            <span style={{ '--level': '76%' }} />
-            <span style={{ '--level': '94%' }} />
+            {telemetry.bars.map((level, index) => (
+              <span
+                key={`${telemetry.label}-${level}`}
+                style={{
+                  '--level': level,
+                  '--delay': `${index * 0.18}s`,
+                }}
+              />
+            ))}
+          </div>
+          <div className={styles.telemetryTrace} aria-hidden="true">
+            {telemetry.trace.map((height, index) => (
+              <span
+                key={`${telemetry.label}-${height}-${index}`}
+                style={{
+                  '--height': height,
+                  '--delay': `${index * 0.12}s`,
+                }}
+              />
+            ))}
           </div>
         </motion.aside>
       </div>

--- a/src/components/Portfolio/portfolio.module.css
+++ b/src/components/Portfolio/portfolio.module.css
@@ -216,6 +216,7 @@
 }
 
 .telemetry {
+  position: relative;
   align-self: center;
   justify-self: end;
   width: min(300px, 100%);
@@ -229,7 +230,22 @@
   overflow: hidden;
 }
 
+.telemetry::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.45;
+  background:
+    linear-gradient(115deg, transparent 0%, rgba(70, 240, 255, 0.12) 42%, transparent 64%);
+  transform: translateX(-120%);
+  animation: telemetrySweep 4.6s ease-in-out infinite;
+  pointer-events: none;
+}
+
 .telemetryHeader {
+  position: relative;
+  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -246,6 +262,9 @@
 }
 
 .telemetryBody {
+  position: relative;
+  z-index: 1;
+  min-height: 102px;
   padding: 16px 14px 10px;
 }
 
@@ -264,6 +283,8 @@
 }
 
 .telemetryBars {
+  position: relative;
+  z-index: 1;
   display: grid;
   gap: 9px;
   padding: 4px 14px 16px;
@@ -283,6 +304,46 @@
   height: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, #46f0ff, #a3e635, #fbbf24);
+  transform-origin: left center;
+  animation: telemetryMeasure 1.9s ease-in-out var(--delay) infinite;
+}
+
+.telemetryTrace {
+  position: relative;
+  z-index: 1;
+  height: 38px;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  align-items: end;
+  gap: 8px;
+  margin: 0 14px 16px;
+  padding: 8px 10px;
+  overflow: hidden;
+  border: 1px solid rgba(70, 240, 255, 0.14);
+  border-radius: 8px;
+  background:
+    linear-gradient(180deg, rgba(70, 240, 255, 0.08), rgba(163, 230, 53, 0.04)),
+    rgba(3, 8, 12, 0.46);
+}
+
+.telemetryTrace::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(70, 240, 255, 0.22), transparent);
+  transform: translateX(-100%);
+  animation: traceScan 2.4s linear infinite;
+}
+
+.telemetryTrace span {
+  position: relative;
+  z-index: 1;
+  height: var(--height);
+  min-height: 8px;
+  border-radius: 999px 999px 2px 2px;
+  background: linear-gradient(180deg, #46f0ff, #a3e635);
+  box-shadow: 0 0 18px rgba(70, 240, 255, 0.28);
+  animation: tracePulse 1.8s ease-in-out var(--delay) infinite;
 }
 
 .scrollCue {
@@ -447,6 +508,70 @@
   background: rgba(15, 23, 42, 0.12);
 }
 
+:global(.theme-light) .telemetryTrace {
+  border-color: rgba(8, 145, 178, 0.16);
+  background:
+    linear-gradient(180deg, rgba(8, 145, 178, 0.08), rgba(101, 163, 13, 0.05)),
+    rgba(255, 255, 255, 0.52);
+}
+
 :global(.theme-light) .scrollCue {
   color: rgba(15, 23, 42, 0.54);
+}
+
+@keyframes telemetrySweep {
+  0%,
+  42% {
+    transform: translateX(-120%);
+  }
+
+  72%,
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+@keyframes telemetryMeasure {
+  0%,
+  100% {
+    transform: scaleX(0.76);
+    filter: saturate(0.9);
+  }
+
+  50% {
+    transform: scaleX(1);
+    filter: saturate(1.22);
+  }
+}
+
+@keyframes traceScan {
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes tracePulse {
+  0%,
+  100% {
+    transform: scaleY(0.72);
+    opacity: 0.66;
+  }
+
+  50% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .telemetry::before,
+  .telemetryBars span::before,
+  .telemetryTrace::before,
+  .telemetryTrace span {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- Opens project details when clicking the body of a Work project card while keeping Live, Source, Details, and Close as independent controls.
- Adds keyboard support for opening details from focused cards.
- Adds a rotating Home telemetry panel with animated measurement bars and signal traces.

## Validation
- Ran `npm.cmd run build` successfully.
- Verified locally that Home telemetry rotates and clicking a Work card opens the matching details panel.